### PR TITLE
Remove default WeatherForecast endpoint

### DIFF
--- a/PersonApi/Controllers/PersonController.cs
+++ b/PersonApi/Controllers/PersonController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using PersonApi.Models;
+
+namespace PersonApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class PersonController : ControllerBase
+    {
+        [HttpGet]
+        public ActionResult<PersonModel> Get()
+        {
+            var rnd = new Random();
+            var person = new PersonModel
+            {
+                Name = "John Smith",
+                Age = rnd.Next(19, 100)
+            };
+            return Ok(person);
+        }
+    }
+}

--- a/PersonApi/Models/PersonModel.cs
+++ b/PersonApi/Models/PersonModel.cs
@@ -1,0 +1,8 @@
+namespace PersonApi.Models
+{
+    public class PersonModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+    }
+}

--- a/PersonApi/PersonApi.csproj
+++ b/PersonApi/PersonApi.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/PersonApi/PersonApi.http
+++ b/PersonApi/PersonApi.http
@@ -1,0 +1,6 @@
+@PersonApi_HostAddress = http://localhost:5017
+
+GET {{PersonApi_HostAddress}}/person
+Accept: application/json
+
+###

--- a/PersonApi/Program.cs
+++ b/PersonApi/Program.cs
@@ -1,0 +1,20 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.MapControllers();
+
+app.Run();

--- a/PersonApi/Properties/launchSettings.json
+++ b/PersonApi/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5017",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7123;http://localhost:5017",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/PersonApi/appsettings.Development.json
+++ b/PersonApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/PersonApi/appsettings.json
+++ b/PersonApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- delete sample WeatherForecast route and model from `Program.cs`
- update `PersonApi.http` to request `/person`

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`

------
https://chatgpt.com/codex/tasks/task_e_68400f9ffd1c83339629b2ac4caae390