### PR TITLE
Add 3-day weather forecast endpoint

### DIFF
--- a/PersonApi/Controllers/WeatherController.cs
+++ b/PersonApi/Controllers/WeatherController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using PersonApi.Models;
+using System.Text.Json;
+
+namespace PersonApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherController : ControllerBase
+    {
+        private readonly HttpClient _client;
+
+        public WeatherController(IHttpClientFactory httpClientFactory)
+        {
+            _client = httpClientFactory.CreateClient();
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<WeatherForecastModel>>> Get([FromQuery] string city)
+        {
+            if (string.IsNullOrWhiteSpace(city))
+            {
+                return BadRequest("City is required.");
+            }
+
+            var url = $"https://wttr.in/{Uri.EscapeDataString(city)}?format=j1";
+            using var stream = await _client.GetStreamAsync(url);
+            using var doc = await JsonDocument.ParseAsync(stream);
+
+            var days = new List<WeatherForecastModel>();
+            var weatherDays = doc.RootElement.GetProperty("weather").EnumerateArray().Take(3);
+
+            foreach (var day in weatherDays)
+            {
+                var desc = day.GetProperty("hourly")[0].GetProperty("weatherDesc")[0].GetProperty("value").GetString() ?? string.Empty;
+                days.Add(new WeatherForecastModel
+                {
+                    Date = DateOnly.Parse(day.GetProperty("date").GetString() ?? string.Empty),
+                    MaxTempC = int.Parse(day.GetProperty("maxtempC").GetString() ?? "0"),
+                    MinTempC = int.Parse(day.GetProperty("mintempC").GetString() ?? "0"),
+                    Description = desc.Trim()
+                });
+            }
+
+            return Ok(days);
+        }
+    }
+}

--- a/PersonApi/Models/WeatherForecastModel.cs
+++ b/PersonApi/Models/WeatherForecastModel.cs
@@ -1,0 +1,10 @@
+namespace PersonApi.Models
+{
+    public class WeatherForecastModel
+    {
+        public DateOnly Date { get; set; }
+        public int MaxTempC { get; set; }
+        public int MinTempC { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/PersonApi/Program.cs
+++ b/PersonApi/Program.cs
@@ -4,6 +4,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- enable `HttpClient` in Program.cs
- create `WeatherForecastModel`
- add `WeatherController` that fetches a 3-day forecast from wttr.in

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a504f4b48333afa3d0a1f6407a81